### PR TITLE
map hdel field to string when given as array

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -10,7 +10,8 @@ class MockRedis
       with_hash_at(key) do |hash|
         if field.is_a?(Array)
           orig_size = hash.size
-          hash.delete_if { |k,v| field.include?(k) }
+          fields    = field.map(&:to_s)
+          hash.delete_if { |k,v| fields.include?(k) }
           orig_size - hash.size
         else
           hash.delete(field.to_s) ? 1 : 0

--- a/spec/commands/hdel_spec.rb
+++ b/spec/commands/hdel_spec.rb
@@ -43,5 +43,12 @@ describe "#hdel(key, field)" do
     @redises.get(@key).should be_nil
   end
 
+  it "treats variable arguments as strings" do
+    field = 2
+    @redises.hset(@key, field, 'two')
+    @redises.hdel(@key, [field])
+    @redises.hget(@key, field).should be_nil
+  end
+
   it_should_behave_like "a hash-only command"
 end


### PR DESCRIPTION
When removing field(s) given as an array to `hdel`, the arguments should be treated as strings for parity with the base case.

For example, the following currently works as expected:

```ruby
$redis.hset('key', 'field', 'val')
# => true
$redis.hget('key', 'field')
# => "val"
$redis.hdel('key', ['field'])
# => 1
$redis.hget('key', 'field')
# => nil
```

When using a single, non-string arg, the field is also deleted:

```ruby
$redis.hset('key', :field, 'val')
# => true
$redis.hget('key', :field)
# => "val"
$redis.hdel('key', :field)
# => 1
$redis.hget('key', :field)
# => nil
```
However, when using the array form with `hdel`, the value is not deleted if a non-string is used:

```ruby
$redis.hset('key', :field, 'val')
# => true
$redis.hget('key', :field)
# => "val"
$redis.hdel('key', [:field])
# => 0
$redis.hget('key', :field)
# => "val"
```

This PR should fix that.