### PR TITLE
Update #(mapped_)hmget to match redis-rb when passed an array

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -75,12 +75,16 @@ class MockRedis
 
     def hmget(key, *fields)
       assert_has_args(fields, 'hmget')
-      fields.map { |f| hget(key, f) }
+      fields.flatten.map { |f| hget(key, f) }
     end
 
     def mapped_hmget(key, *fields)
       reply = hmget(key, *fields)
-      Hash[*fields.zip(reply).flatten]
+      if reply.kind_of?(Array)
+        Hash[fields.zip(reply)]
+      else
+        reply
+      end
     end
 
     def hmset(key, *kvpairs)

--- a/spec/commands/hmget_spec.rb
+++ b/spec/commands/hmget_spec.rb
@@ -11,6 +11,10 @@ describe '#hmget(key, field [, field, ...])' do
     @redises.hmget(@key, 'k1', 'k2').sort.should == %w[v1 v2]
   end
 
+  it 'treats an array as multiple keys' do
+    @redises.hmget(@key, ['k1', 'k2']).sort.should == %w[v1 v2]
+  end
+
   it 'treats the fielsd as strings' do
     @redises.hset(@key, 1, 'one')
     @redises.hset(@key, 2, 'two')

--- a/spec/commands/mapped_hmget_spec.rb
+++ b/spec/commands/mapped_hmget_spec.rb
@@ -15,6 +15,10 @@ describe '#mapped_hmget(key, *fields)' do
       should == { 'k1' => 'v1', 'mock-redis-test:nonesuch' => nil }
   end
 
+  it 'treats an array as the first key' do
+    @redises.mapped_hmget(@key, ['k1', 'k2']).should == { ['k1', 'k2'] => 'v1' }
+  end
+
   it 'raises an error if given no fields' do
     lambda do
       @redises.mapped_hmget(@key)


### PR DESCRIPTION
I ran into this mismatch incidentally by miscalling hmget. I assume
the goal here is to match redis-rb as closely as possible - these
changes bring mock_redis into line with redis-rb in these cases.