### PR TITLE
Preserve Sorted Set elems' lexicographical order

### DIFF
--- a/lib/mock_redis/zset.rb
+++ b/lib/mock_redis/zset.rb
@@ -88,7 +88,7 @@ class MockRedis
     def sorted
       members.map do |m|
         [score(m), m]
-      end.sort_by(&:first)
+      end.sort
     end
 
     def sorted_members

--- a/spec/commands/zrange_spec.rb
+++ b/spec/commands/zrange_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe '#zrange(key, start, stop [, :with_scores => true])' do
   before do
     @key = 'mock-redis-test:zrange'
+    @redises.zadd(@key, 3, 'Jefferson')
     @redises.zadd(@key, 1, 'Washington')
     @redises.zadd(@key, 2, 'Adams')
-    @redises.zadd(@key, 3, 'Jefferson')
     @redises.zadd(@key, 4, 'Madison')
   end
 
@@ -26,6 +26,16 @@ describe '#zrange(key, start, stop [, :with_scores => true])' do
 
   it 'returns the elements in order by score' do
     @redises.zrange(@key, 0, 1).should == %w[Washington Adams]
+  end
+
+  context 'when elements having the same score' do
+    before do
+      @redises.zadd(@key, 1, 'Martha')
+    end
+
+    it 'returns the elements in ascending lexicographical order' do
+      @redises.zrange(@key, 0, 1).should == %w[Martha Washington]
+    end
   end
 
   it 'returns the elements in order by score (negative indices)' do

--- a/spec/commands/zrevrange_spec.rb
+++ b/spec/commands/zrevrange_spec.rb
@@ -24,6 +24,16 @@ describe '#zrevrange(key, start, stop [, :with_scores => true])' do
     @redises.zrevrange(@key, 0, 1).should == %w[Madison Jefferson]
   end
 
+  context 'when elements having the same score' do
+    before do
+      @redises.zadd(@key, 1, 'Martha')
+    end
+
+    it 'returns the elements in descending lexicographical order' do
+      @redises.zrevrange(@key, 3, 4).should == %w[Washington Martha]
+    end
+  end
+
   it 'returns the elements in order by score (negative indices)' do
     @redises.zrevrange(@key, -2, -1).should == %w[Adams Washington]
   end


### PR DESCRIPTION
Use lexicographical order when retrieving sorted set elements having
equal score. Ascending lexicograhpical order is applied to ZRANGE,
whereas descending order is applied to ZREVRANGE.