### PR TITLE
Add a stub for script command

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -224,6 +224,9 @@ class MockRedis
       end
     end
 
+    def script(subcommand, *args)
+    end
+
     private
 
     def assert_valid_timeout(timeout)

--- a/spec/commands/script_spec.rb
+++ b/spec/commands/script_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe '#script(subcommand, *args)' do
+  before { @key = 'mock-redis-test:script' }
+
+  it 'works with load subcommand' do
+    expect { @redises.send_without_checking(:script, :load, 'return 1') }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Hey,

this is not a complete implementation obviously, but I think a complete one is not even feasible (unless you want to include a Lua interpreter in this gem). :smile: 
I encountered this after updating to `redlock-0.1.4`, they introduced script loading into the locking mechanism and that's when my test suite broke, since `mock_redis` does not yet respond to `#script`.

What do you think the best solution here would be? :)
I'm leaning towards that `mock_redis` should at least pretend to understand everything a regular Redis connection can.

Thank you for your gem!