### PR TITLE
Implement missing scripting command stubs: eval, evalsha

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Ruby process.
 
 * `#slowlog` isn't available.
 
-* `#script` is just a stub&mdash;it won't execute anything
+* Scripting commands (`#script`, `#eval`, `#evalsha`) are just stubs&mdash;they won't execute anything
 
 ## Remaining Work
 

--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -227,6 +227,12 @@ class MockRedis
     def script(subcommand, *args)
     end
 
+    def evalsha(*args)
+    end
+
+    def eval(*args)
+    end
+
     private
 
     def assert_valid_timeout(timeout)

--- a/spec/commands/eval_spec.rb
+++ b/spec/commands/eval_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe '#eval(*)' do
+  it 'returns nothing' do
+    @redises.eval('return nil').should be_nil
+  end
+end

--- a/spec/commands/evalsha_spec.rb
+++ b/spec/commands/evalsha_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe '#evalsha(*)' do
+  let(:script) { 'return nil' }
+  let(:script_digest) { Digest::SHA1.hexdigest(script) }
+
+  it 'returns nothing' do
+    @redises.evalsha(script_digest).should be_nil
+  end
+end


### PR DESCRIPTION
@sds here are the missing scripting command stubs. :smile: 

Ref: https://github.com/brigade/mock_redis/pull/112