### PR TITLE
Implement scan and scan_each methods for hash, set, and sorted set

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -109,6 +109,23 @@ class MockRedis
       hmset(key, *kvpairs)
     end
 
+    def hscan(key, cursor, opts = {})
+      opts = opts.merge({
+        key: lambda { |x| x[0] }
+      })
+      common_scan(hgetall(key).to_a, cursor, opts)
+    end
+
+    def hscan_each(key, opts = {}, &block)
+      return to_enum(:hscan_each, key, opts) unless block_given?
+      cursor = 0
+      loop do
+        cursor, values = hscan(key, cursor, opts)
+        values.each(&block)
+        break if cursor == '0'
+      end
+    end
+
     def hset(key, field, value)
       with_hash_at(key) { |h| h[field.to_s] = value.to_s }
       true

--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -110,9 +110,7 @@ class MockRedis
     end
 
     def hscan(key, cursor, opts = {})
-      opts = opts.merge({
-        key: lambda { |x| x[0] }
-      })
+      opts = opts.merge(key: lambda { |x| x[0] })
       common_scan(hgetall(key).to_a, cursor, opts)
     end
 

--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -108,6 +108,20 @@ class MockRedis
       end
     end
 
+    def sscan(key, cursor, opts = {})
+      common_scan(smembers(key), cursor, opts)
+    end
+
+    def sscan_each(key, opts = {}, &block)
+      return to_enum(:sscan_each, key, options) unless block_given?
+      cursor = 0
+      loop do
+        cursor, keys = sscan(key, cursor, options)
+        keys.each(&block)
+        break if cursor == '0'
+      end
+    end
+
     def sunion(*keys)
       assert_has_args(keys, 'sunion')
       with_sets_at(*keys) { |*sets| sets.reduce(&:+).to_a }

--- a/lib/mock_redis/set_methods.rb
+++ b/lib/mock_redis/set_methods.rb
@@ -119,10 +119,10 @@ class MockRedis
     end
 
     def sscan_each(key, opts = {}, &block)
-      return to_enum(:sscan_each, key, options) unless block_given?
+      return to_enum(:sscan_each, key, opts) unless block_given?
       cursor = 0
       loop do
-        cursor, keys = sscan(key, cursor, options)
+        cursor, keys = sscan(key, cursor, opts)
         keys.each(&block)
         break if cursor == '0'
       end

--- a/lib/mock_redis/utility_methods.rb
+++ b/lib/mock_redis/utility_methods.rb
@@ -22,5 +22,21 @@ class MockRedis
         del(key)
       end
     end
+
+    def common_scan(values, cursor, opts = {})
+      count = (opts[:count] || 10).to_i
+      cursor = cursor.to_i
+      match = opts[:match] || '*'
+      key = opts[:key] || lambda { |x| x }
+    
+      limit = cursor + count
+      next_cursor = limit >= values.length ? '0' : limit.to_s
+
+      filtered_values = values[cursor...limit].select do |val|
+        redis_pattern_to_ruby_regex(match) === key.call(val)
+      end
+
+      [next_cursor, filtered_values]
+    end
   end
 end

--- a/lib/mock_redis/utility_methods.rb
+++ b/lib/mock_redis/utility_methods.rb
@@ -28,12 +28,12 @@ class MockRedis
       cursor = cursor.to_i
       match = opts[:match] || '*'
       key = opts[:key] || lambda { |x| x }
-    
+
       limit = cursor + count
       next_cursor = limit >= values.length ? '0' : limit.to_s
 
       filtered_values = values[cursor...limit].select do |val|
-        redis_pattern_to_ruby_regex(match) === key.call(val)
+        redis_pattern_to_ruby_regex(match).match(key.call(val))
       end
 
       [next_cursor, filtered_values]

--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -129,9 +129,7 @@ class MockRedis
     end
 
     def zscan(key, cursor, opts = {})
-      opts = opts.merge({
-        key: lambda { |x| x[0] }
-      })
+      opts = opts.merge(key: lambda { |x| x[0] })
       common_scan(zrange(key, 0, -1, withscores: true), cursor, opts)
     end
 

--- a/spec/commands/hscan_each_spec.rb
+++ b/spec/commands/hscan_each_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe '#hscan_each' do
+  subject { MockRedis::Database.new(self) }
+
+  let(:key) { 'mock-redis-test:hscan_each' }
+
+  before do
+    allow(subject).to receive(:hgetall).and_return(collection)
+  end
+
+  context 'when no keys are found' do
+    let(:collection) { [] }
+
+    it 'does not iterate over any elements' do
+      results = subject.hscan_each(key).map do |k, v|
+        [k, v]
+      end
+      expect(results).to match_array(collection)
+    end
+  end
+
+  context 'when keys are found' do
+    context 'when no match filter is supplied' do
+      let(:collection) { 20.times.map { |i| ["k#{i}", "v#{i}"] } }
+
+      it 'iterates over each item in the collection' do
+        results = subject.hscan_each(key).map do |k, v|
+          [k, v]
+        end
+        expect(results).to match_array(collection)
+      end
+    end
+
+    context 'when giving a custom match filter' do
+      let(:match) { 'k1*' }
+      let(:collection) { 12.times.map { |i| ["k#{i}", "v#{i}"] } }
+      let(:expected) { [['k1', 'v1'], ['k10', 'v10'], ['k11', 'v11']] }
+
+      it 'iterates over each item in the filtered collection' do
+        results = subject.hscan_each(key, match: match).map do |k, v|
+          [k, v]
+        end
+        expect(results).to match_array(expected)
+      end
+    end
+  end
+end

--- a/spec/commands/hscan_each_spec.rb
+++ b/spec/commands/hscan_each_spec.rb
@@ -35,7 +35,7 @@ describe '#hscan_each' do
     context 'when giving a custom match filter' do
       let(:match) { 'k1*' }
       let(:collection) { 12.times.map { |i| ["k#{i}", "v#{i}"] } }
-      let(:expected) { [['k1', 'v1'], ['k10', 'v10'], ['k11', 'v11']] }
+      let(:expected) { [%w[k1 v1], %w[k10 v10], %w[k11 v11]] }
 
       it 'iterates over each item in the filtered collection' do
         results = subject.hscan_each(key, match: match).map do |k, v|

--- a/spec/commands/hscan_spec.rb
+++ b/spec/commands/hscan_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe '#hscan' do
+  let(:count) { 10 }
+  let(:match) { '*' }
+  let(:key) { 'mock-redis-test:hscan' }
+
+  context 'when the hash does not exist' do
+    it 'returns a 0 cursor and an empty collection' do
+      expect(@redises.hscan(key, 0, count: count, match: match)).to eq(['0', []])
+    end
+  end
+
+  context 'when the hash exists' do
+    before do
+      @redises.hset(key, 'k1', 'v1')
+      @redises.hset(key, 'k2', 'v2')
+    end
+
+    let(:expected) { ['0', [['k1', 'v1'], ['k2', 'v2']]] }
+
+    it 'returns a 0 cursor and the collection' do
+      expect(@redises.hscan(key, 0)).to eq(expected)
+    end
+  end
+end

--- a/spec/commands/hscan_spec.rb
+++ b/spec/commands/hscan_spec.rb
@@ -18,7 +18,7 @@ describe '#hscan' do
       @redises.hset(key, 'k3', 'v3')
     end
 
-    let(:expected) { ['0', [['k1', 'v1'], ['k2', 'v2'], ['k3', 'v3']]] }
+    let(:expected) { ['0', [%w[k1 v1], %w[k2 v2], %w[k3 v3]]] }
 
     it 'returns a 0 cursor and the collection' do
       expect(@redises.hscan(key, 0, count: 10)).to eq(expected)

--- a/spec/commands/hscan_spec.rb
+++ b/spec/commands/hscan_spec.rb
@@ -15,12 +15,13 @@ describe '#hscan' do
     before do
       @redises.hset(key, 'k1', 'v1')
       @redises.hset(key, 'k2', 'v2')
+      @redises.hset(key, 'k3', 'v3')
     end
 
-    let(:expected) { ['0', [['k1', 'v1'], ['k2', 'v2']]] }
+    let(:expected) { ['0', [['k1', 'v1'], ['k2', 'v2'], ['k3', 'v3']]] }
 
     it 'returns a 0 cursor and the collection' do
-      expect(@redises.hscan(key, 0)).to eq(expected)
+      expect(@redises.hscan(key, 0, count: 10)).to eq(expected)
     end
   end
 end

--- a/spec/commands/scan_each_spec.rb
+++ b/spec/commands/scan_each_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe '#scan_each' do
+  subject { MockRedis::Database.new(self) }
+
+  let(:match) { '*' }
+
+  before do
+    allow(subject).to receive_message_chain(:data, :keys).and_return(collection)
+  end
+
+  context 'when no keys are found' do
+    let(:collection) { [] }
+
+    it 'does not iterate over any elements' do
+      expect(subject.scan_each.to_a).to be_empty
+    end
+  end
+
+  context 'when keys are found' do
+    context 'when no match filter is supplied' do
+      let(:collection) { 20.times.map { |i| "mock:key#{i}" } }
+
+      it 'iterates over each item in the collection' do
+        expect(subject.scan_each.to_a).to match_array(collection)
+      end
+    end
+
+    context 'when giving a custom match filter' do
+      let(:match) { 'mock:key*' }
+      let(:collection) { %w[mock:key mock:key2 mock:otherkey] }
+      let(:expected) { %w[mock:key mock:key2] }
+
+      it 'iterates over each item in the filtered collection' do
+        expect(subject.scan_each(match: match).to_a).to match_array(expected)
+      end
+    end
+  end
+end

--- a/spec/commands/scan_spec.rb
+++ b/spec/commands/scan_spec.rb
@@ -7,7 +7,7 @@ describe '#scan' do
   let(:match) { '*' }
 
   before do
-    expect(subject).to receive_message_chain(:data, :keys).and_return(collection)
+    allow(subject).to receive_message_chain(:data, :keys).and_return(collection)
   end
 
   context 'when no keys are found' do
@@ -20,11 +20,16 @@ describe '#scan' do
 
   context 'when keys are found' do
     context 'when count is lower than collection size' do
-      let(:collection) { (count + 1).times.map { |i| "mock:key#{i}" } }
-      let(:expected) { [count.to_s, collection] }
+      let(:collection) { (count * 2).times.map { |i| "mock:key#{i}" } }
+      let(:expected_first) { [count.to_s, collection[0...count]] }
+      let(:expected_second) { ['0', collection[count..-1]] }
 
       it 'returns a the next cursor and the collection' do
-        expect(subject.scan(0, count: count, match: match)).to eq(expected)
+        expect(subject.scan(0, count: count, match: match)).to eq(expected_first)
+      end
+
+      it 'returns the correct results of the next cursor' do
+        expect(subject.scan(count, count: count, match: match)).to eq(expected_second)
       end
     end
 

--- a/spec/commands/sscan_each_spec.rb
+++ b/spec/commands/sscan_each_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe '#hscan_each' do
+  subject { MockRedis::Database.new(self) }
+
+  let(:key) { 'mock-redis-test:hscan_each' }
+
+  before do
+    allow(subject).to receive(:smembers).and_return(collection)
+  end
+
+  context 'when no keys are found' do
+    let(:collection) { [] }
+
+    it 'does not iterate over any elements' do
+      results = subject.sscan_each(key).map do |k|
+        k
+      end
+      expect(results).to match_array(collection)
+    end
+  end
+
+  context 'when keys are found' do
+    context 'when no match filter is supplied' do
+      let(:collection) { 20.times.map { |i| "k#{i}" } }
+
+      it 'iterates over each item in the collection' do
+        results = subject.sscan_each(key).map do |k|
+          k
+        end
+        expect(results).to match_array(collection)
+      end
+    end
+
+    context 'when giving a custom match filter' do
+      let(:match) { 'k1*' }
+      let(:collection) { 12.times.map { |i| "k#{i}" } }
+      let(:expected) { ['k1', 'k10', 'k11'] }
+
+      it 'iterates over each item in the filtered collection' do
+        results = subject.sscan_each(key, match: match).map do |k|
+          k
+        end
+        expect(results).to match_array(expected)
+      end
+    end
+  end
+end

--- a/spec/commands/sscan_each_spec.rb
+++ b/spec/commands/sscan_each_spec.rb
@@ -35,7 +35,7 @@ describe '#sscan_each' do
     context 'when giving a custom match filter' do
       let(:match) { 'k1*' }
       let(:collection) { 12.times.map { |i| "k#{i}" } }
-      let(:expected) { ['k1', 'k10', 'k11'] }
+      let(:expected) { %w[k1 k10 k11] }
 
       it 'iterates over each item in the filtered collection' do
         results = subject.sscan_each(key, match: match).map do |k|

--- a/spec/commands/sscan_each_spec.rb
+++ b/spec/commands/sscan_each_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe '#hscan_each' do
+describe '#sscan_each' do
   subject { MockRedis::Database.new(self) }
 
-  let(:key) { 'mock-redis-test:hscan_each' }
+  let(:key) { 'mock-redis-test:sscan_each' }
 
   before do
     allow(subject).to receive(:smembers).and_return(collection)

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe '#hscan' do
+  let(:count) { 10 }
+  let(:match) { '*' }
+  let(:key) { 'mock-redis-test:sscan' }
+
+  context 'when the set does not exist' do
+    it 'returns a 0 cursor and an empty collection' do
+      expect(@redises.sscan(key, 0, count: count, match: match)).to eq(['0', []])
+    end
+  end
+
+  context 'when the set exists' do
+    before do
+      @redises.sadd(key, 'Hello')
+      @redises.sadd(key, 'World')
+      @redises.sadd(key, 'Test')
+    end
+
+    let(:expected) { ['0', ['Test', 'World', 'Hello']] }
+
+    it 'returns a 0 cursor and the collection' do
+      expect(@redises.sscan(key, 0, count: count)).to eq(expected)
+    end
+  end
+end

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -5,6 +5,18 @@ describe '#sscan' do
   let(:match) { '*' }
   let(:key) { 'mock-redis-test:sscan' }
 
+  before do
+    # The return order of the members is non-deterministic, so we sort them to compare
+    expect_any_instance_of(Redis).to receive(:sscan).and_wrap_original do |m, *args|
+      result = m.call(*args)
+      [result[0], result[1].sort]
+    end
+    expect_any_instance_of(MockRedis).to receive(:sscan).and_wrap_original do |m, *args|
+      result = m.call(*args)
+      [result[0], result[1].sort]
+    end
+  end
+
   context 'when the set does not exist' do
     it 'returns a 0 cursor and an empty collection' do
       expect(@redises.sscan(key, 0, count: count, match: match)).to eq(['0', []])
@@ -18,7 +30,7 @@ describe '#sscan' do
       @redises.sadd(key, 'Test')
     end
 
-    let(:expected) { ['0', %w[Test World Hello]] }
+    let(:expected) { ['0', %w[Hello Test World]] }
 
     it 'returns a 0 cursor and the collection' do
       expect(@redises.sscan(key, 0, count: count)).to eq(expected)

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -18,7 +18,7 @@ describe '#sscan' do
       @redises.sadd(key, 'Test')
     end
 
-    let(:expected) { ['0', ['Test', 'World', 'Hello']] }
+    let(:expected) { ['0', %w[Test World Hello]] }
 
     it 'returns a 0 cursor and the collection' do
       expect(@redises.sscan(key, 0, count: count)).to eq(expected)

--- a/spec/commands/sscan_spec.rb
+++ b/spec/commands/sscan_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#hscan' do
+describe '#sscan' do
   let(:count) { 10 }
   let(:match) { '*' }
   let(:key) { 'mock-redis-test:sscan' }

--- a/spec/commands/zscan_each_spec.rb
+++ b/spec/commands/zscan_each_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe '#zscan_each' do
+  subject { MockRedis::Database.new(self) }
+
+  let(:key) { 'mock-redis-test:zscan_each' }
+
+  before do
+    allow(subject).to receive(:zrange).and_return(collection)
+  end
+
+  context 'when no keys are found' do
+    let(:collection) { [] }
+
+    it 'does not iterate over any elements' do
+      results = subject.zscan_each(key).map do |m, s|
+        [m, s]
+      end
+      expect(results).to match_array(collection)
+    end
+  end
+
+  context 'when keys are found' do
+    context 'when no match filter is supplied' do
+      let(:collection) { 20.times.map { |i| ["m#{i}", i] } }
+
+      it 'iterates over each item in the collection' do
+        results = subject.zscan_each(key).map do |m, s|
+          [m, s]
+        end
+        expect(results).to match_array(collection)
+      end
+    end
+
+    context 'when giving a custom match filter' do
+      let(:match) { 'm1*' }
+      let(:collection) { 12.times.map { |i| ["m#{i}", i] } }
+      let(:expected) { [['m1', 1], ['m10', 10], ['m11', 11]] }
+
+      it 'iterates over each item in the filtered collection' do
+        results = subject.zscan_each(key, match: match).map do |m, s|
+          [m, s]
+        end
+        expect(results).to match_array(expected)
+      end
+    end
+  end
+end

--- a/spec/commands/zscan_spec.rb
+++ b/spec/commands/zscan_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe '#zscan' do
+  let(:count) { 10 }
+  let(:match) { '*' }
+  let(:key) { 'mock-redis-test:zscan' }
+
+  context 'when the zset does not exist' do
+    it 'returns a 0 cursor and an empty collection' do
+      expect(@redises.zscan(key, 0, count: count, match: match)).to eq(['0', []])
+    end
+  end
+
+  context 'when the zset exists' do
+    before do
+      @redises.zadd(key, 1.0, 'member1')
+      @redises.zadd(key, 2.0, 'member2')
+    end
+
+    it 'returns a 0 cursor and the collection' do
+      result = @redises.zscan(key, 0)
+      expect(result[0]).to eq('0')
+      expect(result[1]).to match_array([['member1', 1.0], ['member2', 2.0]])
+    end
+  end
+end


### PR DESCRIPTION
Implement scan_each, hscan, hscan_each, sscan, sscan_each, zscan, and zscan_each, along will test coverage for all added methods.