### PR TITLE
[Test] Switch Travis builds to Trusty image for Redis 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: false
 
 cache: bundler
 
+addons:
+  apt:
+    packages:
+      - redis-server
+
 services:
   - redis-server
 
@@ -20,6 +25,7 @@ before_script:
   - git config --local user.name "Travis CI"
 
 script:
+  - redis-cli --version
   - bundle exec rspec
   - bundle exec overcommit --sign
   - bundle exec overcommit --run


### PR DESCRIPTION
We want to be able to run our tests using Redis 3, but we need to switch
to Travis' "Trusty" image in order to accomplish this.