### PR TITLE
raise error in zrem when member is an empty array

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -140,9 +140,13 @@ class MockRedis
         retval = with_zset_at(key) { |z| !!z.delete?(args.first.to_s) }
       else
         args = args.first
-        retval = args.map { |member| !!zscore(key, member.to_s) }.count(true)
-        with_zset_at(key) do |z|
-          args.each { |member| z.delete?(member) }
+        if args.empty?
+          raise Redis::CommandError, "ERR wrong number of arguments for 'zrem' command"
+        else
+          retval = args.map { |member| !!zscore(key, member.to_s) }.count(true)
+          with_zset_at(key) do |z|
+            args.each { |member| z.delete?(member) }
+          end
         end
       end
 

--- a/spec/commands/zrem_spec.rb
+++ b/spec/commands/zrem_spec.rb
@@ -33,5 +33,11 @@ describe '#zrem(key, member)' do
     @redises.zrange(@key, 0, -1).should be_empty
   end
 
+  it 'raises an error if member is an empty array' do
+    lambda do
+      @redises.zrem(@key, [])
+    end.should raise_error(Redis::CommandError)
+  end
+
   it_should_behave_like 'a zset-only command'
 end


### PR DESCRIPTION
This fixes #119.

I've tried to keep both the code and the example that verifies the behaviour in the style of the rest.

Please let me know, if there is anything I've missed.