### PR TITLE
Improve performance of operations with an expiration.

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -304,10 +304,10 @@ class MockRedis
     def set_expiration(key, time)
       remove_expiration(key)
 
-      expire_times << [time, key.to_s]
-      expire_times.sort! do |a, b|
-        a.first <=> b.first
-      end
+      index = expire_times.bsearch_index do |(t, k)|
+        t >= time
+      end || -1
+      expire_times.insert(index, [time, key.to_s])
     end
 
     def zero_pad(string, desired_length)


### PR DESCRIPTION
See issue #118

This PR improves the performance of the of operations with expiration. The performance issue is due to the `expire_times` data structure in the `Database` class. The PR improves the performance by inserting the key-time pair in the `expire_times` Array at the correct position instead of inserting it at the end and re-sorting.

These are the results on my machine for the script mentioned in #118 with 10,000 keys.

```
# before
[mdalton@mdalton-MacBook-Pro-7 mock_redis (master)]$ bundle exec ruby performance.rb
setex
25.877892246004194
set
0.16075976501451805
```

```
# after
[mdalton@mdalton-MacBook-Pro-7 mock_redis (master)]$ bundle exec ruby performance.rb
setex
6.0611226839828305
set
0.13644369100802578
```

My first attempt to fix this issue was to change the data structure for `expire_times` from an `Array` to a `Hash`. I thought this would speed things up since most operations on this data structure in the `Database` class would be performed in constant time with a `Hash` but are linear time with an `Array`. However, when I made this change, the time actually increased. I realized that the reason it was a sorted `Array` to begin with was because it is optimized for the `expire_keys` method.

Even though this PR does not prevent the exponential degradation, it does improve it.

Let me know your thoughts.
