### PR TITLE
flatten the args for hmset

### DIFF
--- a/lib/mock_redis/hash_methods.rb
+++ b/lib/mock_redis/hash_methods.rb
@@ -88,6 +88,7 @@ class MockRedis
     end
 
     def hmset(key, *kvpairs)
+      kvpairs.flatten!
       assert_has_args(kvpairs, 'hmset')
       if kvpairs.length.odd?
         raise Redis::CommandError, 'ERR wrong number of arguments for HMSET'


### PR DESCRIPTION
I ran into a bug with mock_redis for the `#hmset` method.  Using this method with `redis-rb`, you can pass your arguments like this:

```
client.hmset('my_key', ['one', 1, 'two', 2])
```

-OR-

```
client.hmset('my_key', 'one', 1, 'two', 2)
```

`mock_redis` only supports the latter, and thus my working application code didn't pass the tests.

The fix is simple, merely flatten the splatted array args.  No problem!

@sds, take a look!  Thanks.
