### PR TITLE
Handle negative out of bounds start in zrange

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -118,7 +118,9 @@ class MockRedis
 
     def zrange(key, start, stop, options = {})
       with_zset_at(key) do |z|
-        to_response(z.sorted[start.to_i..stop.to_i] || [], options)
+        start = [start.to_i, -z.sorted.size].max
+        stop = [stop.to_i, -z.sorted.size].max
+        to_response(z.sorted[start..stop] || [], options)
       end
     end
 

--- a/spec/commands/zrange_spec.rb
+++ b/spec/commands/zrange_spec.rb
@@ -46,6 +46,22 @@ describe '#zrange(key, start, stop [, :with_scores => true])' do
     @redises.zrange(@key, 5, -1).should == []
   end
 
+  it 'returns entire list when start is out of bounds with negative end in bounds' do
+    @redises.zrange(@key, -5, -1).should == %w[Washington Adams Jefferson Madison]
+  end
+
+  it 'returns correct subset when start is out of bounds with positive end in bounds' do
+    @redises.zrange(@key, -5, 1).should == %w[Washington Adams]
+  end
+
+  it 'returns empty list when start is in bounds with negative end out of bounds' do
+    @redises.zrange(@key, 1, -5).should == []
+  end
+
+  it 'returns correct subset when start is in bounds with negative end in bounds' do
+    @redises.zrange(@key, 1, -1).should == %w[Adams Jefferson Madison]
+  end
+
   it 'returns the scores when :with_scores is specified' do
     @redises.zrange(@key, 0, 1, :with_scores => true).
       should == [['Washington', 1.0], ['Adams', 2.0]]


### PR DESCRIPTION
The Redis zrange command can handle out of bounds negative start index. Ruby arrays can't do this (returns nil. See: http://apidock.com/ruby/Array/%5B%5D). This commit provides a small update to the mock zrange command to provide this functionality. Discovered when writing a test that invoked a method which used this command: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L519