### PR TITLE
Fix #zrange behavior with negative stop argument

### DIFF
--- a/lib/mock_redis/zset_methods.rb
+++ b/lib/mock_redis/zset_methods.rb
@@ -119,7 +119,7 @@ class MockRedis
     def zrange(key, start, stop, options = {})
       with_zset_at(key) do |z|
         start = [start.to_i, -z.sorted.size].max
-        stop = [stop.to_i, -z.sorted.size].max
+        stop = stop.to_i
         to_response(z.sorted[start..stop] || [], options)
       end
     end

--- a/spec/commands/zrange_spec.rb
+++ b/spec/commands/zrange_spec.rb
@@ -58,6 +58,10 @@ describe '#zrange(key, start, stop [, :with_scores => true])' do
     @redises.zrange(@key, 1, -5).should == []
   end
 
+  it 'returns empty list when start is 0 with negative end out of bounds' do
+    @redises.zrange(@key, 0, -5).should == []
+  end
+
   it 'returns correct subset when start is in bounds with negative end in bounds' do
     @redises.zrange(@key, 1, -1).should == %w[Adams Jefferson Madison]
   end


### PR DESCRIPTION
Addresses https://github.com/brigade/mock_redis/issues/131. 

The existing code was capping the negative STOP argument at the negative size of the zset. But when START is 0, this means that the first element of the zset is included no matter the STOP argument.