### PR TITLE
Transaction nested within pipeline bug fix

### DIFF
--- a/lib/mock_redis/future.rb
+++ b/lib/mock_redis/future.rb
@@ -2,10 +2,11 @@ class MockRedis
   class FutureNotReady < RuntimeError; end
 
   class Future
-    attr_reader :command
+    attr_reader :command, :block
 
-    def initialize(command)
+    def initialize(command, block = nil)
       @command = command
+      @block = block
       @result_set = false
     end
 

--- a/lib/mock_redis/pipelined_wrapper.rb
+++ b/lib/mock_redis/pipelined_wrapper.rb
@@ -32,7 +32,7 @@ class MockRedis
       @in_pipeline = true
       yield self
       @in_pipeline = false
-      responses = @pipelined_futures.map do |future|
+      responses = @pipelined_futures.flat_map do |future|
         begin
           if future.block
             result = send(*future.command, &future.block)

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -67,6 +67,18 @@ describe 'transactions (multi/exec/discard)' do
       @redises.get('counter').should == '6'
       @redises.get('test').should == '1'
     end
+
+    it 'allows multi blocks within pipelined blocks' do
+      @redises.set('counter', 5)
+      @redises.pipelined do |pr|
+        pr.multi do |r|
+          r.set('test', 1)
+          r.incr('counter')
+        end
+      end
+      @redises.get('counter').should == '6'
+      @redises.get('test').should == '1'
+    end
   end
 
   context '#discard' do


### PR DESCRIPTION
Closes #144 

Problem occurs when PipelinedWrapper is set to `@in_pipeline = true`, multi call with a block gets saved to a future, which does not know how to save a block. Thus, everything happening within nested multi block gets lost. When pipelined block finishes and starts executing futures, there's only multi call without block which returns OK, and sets db to `@in_multi=true`.

Couple of words about my solution:

Same solution that is used for nested pipelined blocks within multi blocks does not work other way around, since `PipelinedWrapper` getting yielded to multi block in this case pushes them down the stack to multi wrapper that is not in multi mode, so any calls to multi-specific methods like `#discard` will return an error.

Working around that by explicitly setting multi wrapper to multi mode from PipelinedWrapper `#multi` seems to violate my understanding of good OOP practices.

So, what I ended up doing is training Futures to store blocks coming with method calls as well, and passing these blocks along with arguments when pipelined block exits.

Now, at first I wanted to unify this approach and allow pipelined block within multi block to work the same way, but turns out that this won't work. When multi-specific methods are called from nested pipelined block in such way, they get stored in pipelined wrapper's futures store, and only get executed when `@in_multi` is set to false, resulting in failure for `#discard` and friends.

Thus, hybrid approach.