### PR TITLE
Fix pipelined array replies

### DIFF
--- a/lib/mock_redis/pipelined_wrapper.rb
+++ b/lib/mock_redis/pipelined_wrapper.rb
@@ -40,7 +40,12 @@ class MockRedis
                      send(*future.command)
                    end
           future.store_result(result)
-          result
+
+          if future.block
+            result
+          else
+            [result]
+          end
         rescue StandardError => e
           e
         end

--- a/spec/commands/pipelined_spec.rb
+++ b/spec/commands/pipelined_spec.rb
@@ -39,4 +39,30 @@ describe '#pipelined' do
       future.class.should be MockRedis::Future
     end
   end
+
+  context 'with pipelined operations returning array replies' do
+    let(:key1) { 'colors' }
+    let(:key2) { 'seasons' }
+    let(:value1) { %w[blue yellow] }
+    let(:value2) { %w[summer winter] }
+
+    before do
+      @redises.rpush(key1, value1)
+      @redises.rpush(key2, value2)
+    end
+
+    after do
+      @redises.del key1
+      @redises.del key2
+    end
+
+    it 'returns an array of the array replies' do
+      results = @redises.pipelined do |redis|
+        @redises.lrange(key1, 0, -1)
+        @redises.lrange(key2, 0, -1)
+      end
+
+      results.should == [value1, value2]
+    end
+  end
 end

--- a/spec/transactions_spec.rb
+++ b/spec/transactions_spec.rb
@@ -67,18 +67,6 @@ describe 'transactions (multi/exec/discard)' do
       @redises.get('counter').should == '6'
       @redises.get('test').should == '1'
     end
-
-    it 'allows multi blocks within pipelined blocks' do
-      @redises.set('counter', 5)
-      @redises.pipelined do |pr|
-        pr.multi do |r|
-          r.set('test', 1)
-          r.incr('counter')
-        end
-      end
-      @redises.get('counter').should == '6'
-      @redises.get('test').should == '1'
-    end
   end
 
   context '#discard' do


### PR DESCRIPTION
Array replies were being flatted, when the result of #pipelined
should be an array of the values returns by each individual operation.