### PR TITLE
Improve performance of set_expiration

### DIFF
--- a/lib/mock_redis/database.rb
+++ b/lib/mock_redis/database.rb
@@ -305,11 +305,9 @@ class MockRedis
 
     def set_expiration(key, time)
       remove_expiration(key)
-
-      expire_times << [time, key.to_s]
-      expire_times.sort! do |a, b|
-        a.first <=> b.first
-      end
+      found = expire_times.each_with_index.to_a.bsearch { |item, _| item.first >= time }
+      index = found ? found.last : -1
+      expire_times.insert(index, [time, key.to_s])
     end
 
     def zero_pad(string, desired_length)


### PR DESCRIPTION
Fixes #118 and #121 

`Array.bsearch` is in ruby 2.0.

The difference with #121 is that here we manually build the index search using plain bsearch _item_ on the array of (item, index) pairs, and then extract the index from it.



Before:
```
> bundle exec ruby performance.rb
setex
21.502102999947965
set
0.09983500000089407
```

After:
```
> bundle exec ruby performance.rb
setex
7.995712999952957
set
0.08754800003953278
```

Test file:
```ruby
require 'mock_redis'
require 'benchmark'

VALS = Array.new(10_000) do |i|
  ["some_key:#{i}", 3000 + rand(10)]
end

mr = MockRedis.new

puts 'setex', (
  Benchmark.realtime do
    VALS.each do |key, exp|
      mr.setex(key, exp, 'some value')
    end
  end
)

puts 'set', (
  Benchmark.realtime do
    VALS.each do |key, exp|
      mr.set(key, 'some value')
    end
  end
)
```