### PR TITLE
Fix watch to allow multiple keys

### DIFF
--- a/lib/mock_redis/transaction_wrapper.rb
+++ b/lib/mock_redis/transaction_wrapper.rb
@@ -108,7 +108,7 @@ class MockRedis
       'OK'
     end
 
-    def watch(_)
+    def watch(*_)
       if block_given?
         yield self
       else

--- a/spec/commands/watch_spec.rb
+++ b/spec/commands/watch_spec.rb
@@ -1,12 +1,17 @@
 require 'spec_helper'
 
-describe '#watch(key)' do
+describe '#watch(key [, key, ...)' do
+  before do
+    @key1 = 'mock-redis-test-watch1'
+    @key2 = 'mock-redis-test-watch2'
+  end
+
   it "returns 'OK'" do
-    @redises.watch('mock-redis-test').should == 'OK'
+    @redises.watch(@key1, @key2).should == 'OK'
   end
 
   it 'EXECs its MULTI on successes' do
-    @redises.watch 'foo' do
+    @redises.watch @key1, @key2 do
       @redises.multi do |multi|
         multi.set 'bar', 'baz'
       end


### PR DESCRIPTION
`watch` should be allowed to accept multiple keys as in `redis-rb` (https://github.com/redis/redis-rb/blob/448322f0faff320eacec82682314edefb1b12036/lib/redis.rb#L2372)