### PR TITLE
Fix get set reversibility

### DIFF
--- a/lib/mock_redis/string_methods.rb
+++ b/lib/mock_redis/string_methods.rb
@@ -85,6 +85,7 @@ class MockRedis
     end
 
     def get(key)
+      key = key.to_s
       assert_stringy(key)
       data[key]
     end

--- a/spec/commands/get_spec.rb
+++ b/spec/commands/get_spec.rb
@@ -24,6 +24,7 @@ describe '#get(key)' do
 
     @redises.set(key, 'hello')
     @redises.get(key.to_s).should == 'hello'
+    @redises.get(key).should == 'hello'
   end
 
   it_should_behave_like 'a string-only command'

--- a/spec/commands/xadd_spec.rb
+++ b/spec/commands/xadd_spec.rb
@@ -49,7 +49,7 @@ describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, app
   end
 
   it 'raises exception if id of 0 is added to an empty stream' do
-    expect { @redises.xadd('unknown-stream', { key: 'value' }, id: '0') }
+    expect { @redises.xadd('mock-redis-test:unknown-stream', { key: 'value' }, id: '0') }
       .to raise_error(
         Redis::CommandError,
         'ERR The ID specified in XADD is equal or smaller than the target ' \
@@ -58,7 +58,7 @@ describe '#xadd("mystream", { f1: "v1", f2: "v2" }, id: "0-0", maxlen: 1000, app
   end
 
   it 'does not raise exception on empty stream with id of 0 and positive sequence number' do
-    expect { @redises.xadd('unknown-stream', { key: 'value' }, id: '0-1') }
+    expect { @redises.xadd('mock-redis-test:unknown-stream', { key: 'value' }, id: '0-1') }
       .to_not raise_error
   end
 


### PR DESCRIPTION
Related to this issue: https://github.com/brigade/mock_redis/issues/157

Right now, the mock redis `SET` converts the key to a string but the `GET` method does not.

* This PR adds the conversion into the `GET` method and adds an another assertion to the current test that was supposed to catch this.
* This also adds a fix to the `xadd` tests where the keys were getting set without the prefix `mock-redis-test:`, so that multiple runs of the test suite were failing

Please let me know if you'd like any adjustments

